### PR TITLE
#237 - fix: Inject user connection name attribute to allow resource import

### DIFF
--- a/patches/0001-Add-a-shim.patch
+++ b/patches/0001-Add-a-shim.patch
@@ -1,12 +1,8 @@
-From faa437a52d74af80d5c0960a92866a8d95d62da2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Mikhail Shilkov <github@mikhail.io>
 Date: Tue, 19 Sep 2023 17:21:23 +0200
-Subject: [PATCH 1/2] Add a shim
+Subject: [PATCH 1/3] Add a shim
 
----
- shim/shim.go | 10 ++++++++++
- 1 file changed, 10 insertions(+)
- create mode 100644 shim/shim.go
 
 diff --git a/shim/shim.go b/shim/shim.go
 new file mode 100644
@@ -24,6 +20,3 @@ index 00000000..3c127eb3
 +func NewProvider() *schema.Provider {
 +	return provider.New()
 +}
--- 
-2.39.3 (Apple Git-145)
-

--- a/patches/0002-Patch-to-avoid-upstream-ResourceServer-panic-code-mo.patch
+++ b/patches/0002-Patch-to-avoid-upstream-ResourceServer-panic-code-mo.patch
@@ -1,11 +1,8 @@
-From 674eeedaf4dd11c5936c347d2edc766f7256c58f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Thomas Kappler <tkappler@pulumi.com>
 Date: Fri, 29 Sep 2023 07:52:53 +0200
-Subject: [PATCH 2/2] Patch to avoid upstream ResourceServer panic: code moved
+Subject: [PATCH 2/3] Patch to avoid upstream ResourceServer panic: code moved
 
----
- internal/auth0/resourceserver/expand.go | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/internal/auth0/resourceserver/expand.go b/internal/auth0/resourceserver/expand.go
 index ee1e6e97..5b1c23fa 100644
@@ -19,6 +16,3 @@ index ee1e6e97..5b1c23fa 100644
 +	name := state.GetAttr("name")
 +	return !name.IsNull() && name.AsString() == auth0ManagementAPIName
  }
--- 
-2.39.3 (Apple Git-145)
-

--- a/patches/0003-Patch-to-allow-allow-User-resource-import-inject-con.patch
+++ b/patches/0003-Patch-to-allow-allow-User-resource-import-inject-con.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Fabrice Baumann <fa.baumann@gmail.com>
+Date: Thu, 7 Mar 2024 16:31:48 -0500
+Subject: [PATCH 3/3] Patch to allow allow User resource import: inject
+ connection name attribute
+
+
+diff --git a/internal/auth0/user/flatten.go b/internal/auth0/user/flatten.go
+index 9efdaa08..765b8c57 100644
+--- a/internal/auth0/user/flatten.go
++++ b/internal/auth0/user/flatten.go
+@@ -21,6 +21,7 @@ func flattenUser(data *schema.ResourceData, user *management.User) (err error) {
+ 	result := multierror.Append(
+ 		data.Set("user_id", user.GetID()),
+ 		data.Set("username", user.GetUsername()),
++		data.Set("connection_name", user.GetConnection()),
+ 		data.Set("name", user.GetName()),
+ 		data.Set("family_name", user.GetFamilyName()),
+ 		data.Set("given_name", user.GetGivenName()),
+diff --git a/internal/auth0/user/resource.go b/internal/auth0/user/resource.go
+index bd9258ed..faddb005 100644
+--- a/internal/auth0/user/resource.go
++++ b/internal/auth0/user/resource.go
+@@ -175,6 +175,11 @@ func readUser(ctx context.Context, data *schema.ResourceData, meta interface{})
+ 		return diag.FromErr(internalError.HandleAPIError(data, err))
+ 	}
+ 
++	if len(user.Identities) == 1 {
++		userIdentity := user.Identities[0]
++		user.Connection = userIdentity.Connection
++	}
++
+ 	return diag.FromErr(flattenUser(data, user))
+ }
+ 


### PR DESCRIPTION
Fixes #237

I'm unsure why the path commits were modified to `0000000000000000000000000000000000000000`, I guess I must have made a mistake somewhere.

here are the steps I followed:

```
- make upstream
- make upstream.rebase
- I made the changes to upstream/internal/auth0/user/flatten.go and upstream/internal/auth0/user/resource.go then created a new git commit
- make upstream.finalize
```

I generated a build of the plugin and the python SDK and tested this change locally and I can confirm that the connectionName is properly imported and does not generate a change anymore

before the patch:

```text
warning: inputs to import do not match the existing resource; importing this resource will fail
    = auth0:index/user:User: (import)
        [id=auth0|65b3cf64d3feda60bbc6bd01]
        [urn=urn:pulumi:dev::test-pulumi-auth0::auth0:index/user:User::this]
        [provider=urn:pulumi:dev::test-pulumi-auth0::pulumi:providers:auth0::this::04da6b54-80e4-46f7-96ec-b56ff0331ba9]
      + connectionName: "c63b249c-47ce-4c26-a2c6-20dd9101af86-LocalUserDatabase"
```

with the patch

```text
    = auth0:index/user:User: (import)
        [id=auth0|65b3cf64d3feda60bbc6bd01]
        [urn=urn:pulumi:dev::test-pulumi-auth0::auth0:index/user:User::this]
        [provider=urn:pulumi:dev::test-pulumi-auth0::pulumi:providers:auth0::this::04da6b54-80e4-46f7-96ec-b56ff0331ba9]
        connectionName: "c63b249c-47ce-4c26-a2c6-20dd9101af86-LocalUserDatabase"
        email         : "me@example.com"
        name          : "Administrator"
        nickname      : "administrator"
        picture       : "https://s.gravatar.com/avatar/b3a263843d9b28612b381b3a01e4543c?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fla.png"
        userId        : "auth0|65b3cf64d3feda60bbc6bd01"

```