### PR TITLE
Make tests work for both PRC and non-PRC

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -27,8 +27,467 @@ func server() pulumirpc.ResourceProviderServer {
 	)
 }
 
-func TestConnectionMigration(t *testing.T) {
-	testutils.ReplaySequence(t, server(), `[
+const nonPrcGrpc = `[
+        {
+            "method": "/pulumirpc.ResourceProvider/Diff",
+            "request": {
+                "id": "con_28GC8g8h3O4RUSSM",
+                "urn": "urn:pulumi:dev::dev-yaml::auth0:index/connection:Connection::googleOauth2",
+                "olds": {
+                    "__meta": "{\"schema_version\":\"2\"}",
+                    "displayName": "",
+                    "enabledClients": [],
+                    "id": "con_28GC8g8h3O4RUSSM",
+                    "isDomainConnection": false,
+                    "name": "googleOauth2-b68d006",
+                    "options": {
+                        "adfsServer": "",
+                        "allowedAudiences": [
+                            "api.example.com",
+                            "example.com"
+                        ],
+                        "apiEnableUsers": false,
+                        "appDomain": "",
+                        "appId": "",
+                        "authorizationEndpoint": "",
+                        "bruteForceProtection": false,
+                        "clientId": "",
+                        "clientSecret": "",
+                        "communityBaseUrl": "",
+                        "configuration": {},
+                        "customScripts": {},
+                        "debug": false,
+                        "digestAlgorithm": "",
+                        "disableCache": false,
+                        "disableSignup": false,
+                        "discoveryUrl": "",
+                        "domain": "",
+                        "domainAliases": [],
+                        "enabledDatabaseCustomization": false,
+                        "entityId": "",
+                        "fieldsMap": {},
+                        "forwardRequestInfo": false,
+                        "from": "",
+                        "gatewayAuthentication": null,
+                        "gatewayUrl": "",
+                        "iconUrl": "",
+                        "identityApi": "",
+                        "idpInitiated": null,
+                        "importMode": false,
+                        "ips": [],
+                        "issuer": "",
+                        "jwksUri": "",
+                        "keyId": "",
+                        "maxGroupsToRetrieve": "",
+                        "messagingServiceSid": "",
+                        "mfa": null,
+                        "name": "",
+                        "nonPersistentAttrs": [
+                            "ethnicity",
+                            "gender"
+                        ],
+                        "passwordComplexityOptions": null,
+                        "passwordDictionary": null,
+                        "passwordHistories": [],
+                        "passwordNoPersonalInfo": null,
+                        "passwordPolicy": "",
+                        "protocolBinding": "",
+                        "provider": "",
+                        "requestTemplate": "",
+                        "requiresUsername": false,
+                        "scopes": [
+                            "youtube",
+                            "gmail",
+                            "profile",
+                            "email"
+                        ],
+                        "scripts": {},
+                        "setUserRootAttributes": "on_each_login",
+                        "shouldTrustEmailVerifiedConnection": "",
+                        "signInEndpoint": "",
+                        "signOutEndpoint": "",
+                        "signSamlRequest": false,
+                        "signatureAlgorithm": "",
+                        "signingCert": "",
+                        "strategyVersion": 0,
+                        "subject": "",
+                        "syntax": "",
+                        "teamId": "",
+                        "template": "",
+                        "tenantDomain": "",
+                        "tokenEndpoint": "",
+                        "totp": null,
+                        "twilioSid": "",
+                        "twilioToken": "",
+                        "type": "",
+                        "useCertAuth": false,
+                        "useKerberos": false,
+                        "useWsfed": false,
+                        "userIdAttribute": "",
+                        "userinfoEndpoint": "",
+                        "validation": null,
+                        "waadCommonEndpoint": false,
+                        "waadProtocol": ""
+                    },
+                    "realms": [
+                        "googleOauth2-b68d006"
+                    ],
+                    "strategy": "google-oauth2"
+                },
+                "news": {
+                    "__defaults": [
+                        "name"
+                    ],
+                    "name": "googleOauth2-b68d006",
+                    "options": {
+                        "__defaults": [],
+                        "allowedAudiences": [
+                            "example.com",
+                            "api.example.com"
+                        ],
+                        "nonPersistentAttrs": [
+                            "ethnicity",
+                            "gender"
+                        ],
+                        "scopes": [
+                            "email",
+                            "profile",
+                            "gmail",
+                            "youtube"
+                        ],
+                        "setUserRootAttributes": "on_each_login"
+                    },
+                    "strategy": "google-oauth2"
+                },
+                "oldInputs": {
+                    "__defaults": [
+                        "name"
+                    ],
+                    "name": "googleOauth2-b68d006",
+                    "options": {
+                        "__defaults": [],
+                        "allowedAudiences": [
+                            "example.com",
+                            "api.example.com"
+                        ],
+                        "nonPersistentAttrs": [
+                            "ethnicity",
+                            "gender"
+                        ],
+                        "scopes": [
+                            "email",
+                            "profile",
+                            "gmail",
+                            "youtube"
+                        ],
+                        "setUserRootAttributes": "on_each_login"
+                    },
+                    "strategy": "google-oauth2"
+                }
+            },
+            "response": {
+                "stables": "*",
+                "changes": "DIFF_SOME",
+                "diffs": [
+                    "options"
+                ],
+                "detailedDiff": {
+                    "options.fieldsMap": {
+                        "kind": "DELETE"
+                    }
+                },
+                "hasDetailedDiff": true
+            },
+            "metadata": {
+                "kind": "resource",
+                "mode": "client",
+                "name": "auth0"
+            }
+        },
+        {
+            "method": "/pulumirpc.ResourceProvider/Update",
+            "request": {
+                "id": "con_28GC8g8h3O4RUSSM",
+                "urn": "urn:pulumi:dev::dev-yaml::auth0:index/connection:Connection::googleOauth2",
+                "olds": {
+                    "__meta": "{\"schema_version\":\"2\"}",
+                    "displayName": "",
+                    "enabledClients": [],
+                    "id": "con_28GC8g8h3O4RUSSM",
+                    "isDomainConnection": false,
+                    "name": "googleOauth2-b68d006",
+                    "options": {
+                        "adfsServer": "",
+                        "allowedAudiences": [
+                            "api.example.com",
+                            "example.com"
+                        ],
+                        "apiEnableUsers": false,
+                        "appDomain": "",
+                        "appId": "",
+                        "authorizationEndpoint": "",
+                        "bruteForceProtection": false,
+                        "clientId": "",
+                        "clientSecret": "",
+                        "communityBaseUrl": "",
+                        "configuration": {},
+                        "customScripts": {},
+                        "debug": false,
+                        "digestAlgorithm": "",
+                        "disableCache": false,
+                        "disableSignup": false,
+                        "discoveryUrl": "",
+                        "domain": "",
+                        "domainAliases": [],
+                        "enabledDatabaseCustomization": false,
+                        "entityId": "",
+                        "fieldsMap": {},
+                        "forwardRequestInfo": false,
+                        "from": "",
+                        "gatewayAuthentication": null,
+                        "gatewayUrl": "",
+                        "iconUrl": "",
+                        "identityApi": "",
+                        "idpInitiated": null,
+                        "importMode": false,
+                        "ips": [],
+                        "issuer": "",
+                        "jwksUri": "",
+                        "keyId": "",
+                        "maxGroupsToRetrieve": "",
+                        "messagingServiceSid": "",
+                        "mfa": null,
+                        "name": "",
+                        "nonPersistentAttrs": [
+                            "ethnicity",
+                            "gender"
+                        ],
+                        "passwordComplexityOptions": null,
+                        "passwordDictionary": null,
+                        "passwordHistories": [],
+                        "passwordNoPersonalInfo": null,
+                        "passwordPolicy": "",
+                        "protocolBinding": "",
+                        "provider": "",
+                        "requestTemplate": "",
+                        "requiresUsername": false,
+                        "scopes": [
+                            "youtube",
+                            "gmail",
+                            "profile",
+                            "email"
+                        ],
+                        "scripts": {},
+                        "setUserRootAttributes": "on_each_login",
+                        "shouldTrustEmailVerifiedConnection": "",
+                        "signInEndpoint": "",
+                        "signOutEndpoint": "",
+                        "signSamlRequest": false,
+                        "signatureAlgorithm": "",
+                        "signingCert": "",
+                        "strategyVersion": 0,
+                        "subject": "",
+                        "syntax": "",
+                        "teamId": "",
+                        "template": "",
+                        "tenantDomain": "",
+                        "tokenEndpoint": "",
+                        "totp": null,
+                        "twilioSid": "",
+                        "twilioToken": "",
+                        "type": "",
+                        "useCertAuth": false,
+                        "useKerberos": false,
+                        "useWsfed": false,
+                        "userIdAttribute": "",
+                        "userinfoEndpoint": "",
+                        "validation": null,
+                        "waadCommonEndpoint": false,
+                        "waadProtocol": ""
+                    },
+                    "realms": [
+                        "googleOauth2-b68d006"
+                    ],
+                    "strategy": "google-oauth2"
+                },
+                "news": {
+                    "__defaults": [
+                        "name"
+                    ],
+                    "name": "googleOauth2-b68d006",
+                    "options": {
+                        "__defaults": [],
+                        "allowedAudiences": [
+                            "example.com",
+                            "api.example.com"
+                        ],
+                        "nonPersistentAttrs": [
+                            "ethnicity",
+                            "gender"
+                        ],
+                        "scopes": [
+                            "email",
+                            "profile",
+                            "gmail",
+                            "youtube"
+                        ],
+                        "setUserRootAttributes": "on_each_login"
+                    },
+                    "strategy": "google-oauth2"
+                },
+                "preview": true,
+                "oldInputs": {
+                    "__defaults": [
+                        "name"
+                    ],
+                    "name": "googleOauth2-b68d006",
+                    "options": {
+                        "__defaults": [],
+                        "allowedAudiences": [
+                            "example.com",
+                            "api.example.com"
+                        ],
+                        "nonPersistentAttrs": [
+                            "ethnicity",
+                            "gender"
+                        ],
+                        "scopes": [
+                            "email",
+                            "profile",
+                            "gmail",
+                            "youtube"
+                        ],
+                        "setUserRootAttributes": "on_each_login"
+                    },
+                    "strategy": "google-oauth2"
+                }
+            },
+            "response": {
+                "properties": {
+                    "__meta": "{\"schema_version\":\"2\"}",
+                    "displayName": "",
+                    "id": "con_28GC8g8h3O4RUSSM",
+                    "isDomainConnection": false,
+                    "name": "googleOauth2-b68d006",
+                    "options": {
+                        "adfsServer": "",
+                        "allowedAudiences": [
+                            "api.example.com",
+                            "example.com"
+                        ],
+                        "apiEnableUsers": false,
+                        "appId": "",
+                        "attributeMap": null,
+                        "authParams": {},
+                        "authorizationEndpoint": "",
+                        "bruteForceProtection": false,
+                        "clientId": "",
+                        "clientSecret": "",
+                        "communityBaseUrl": "",
+                        "configuration": {},
+                        "connectionSettings": null,
+                        "customScripts": {},
+                        "debug": false,
+                        "decryptionKey": null,
+                        "digestAlgorithm": "",
+                        "disableCache": false,
+                        "disableSelfServiceChangePassword": false,
+                        "disableSignOut": false,
+                        "disableSignup": false,
+                        "discoveryUrl": "",
+                        "domain": "",
+                        "domainAliases": [],
+                        "enableScriptContext": false,
+                        "enabledDatabaseCustomization": false,
+                        "entityId": "",
+                        "fedMetadataXml": "",
+                        "fieldsMap": "",
+                        "forwardRequestInfo": false,
+                        "from": "",
+                        "gatewayAuthentication": null,
+                        "gatewayUrl": "",
+                        "iconUrl": "",
+                        "identityApi": "",
+                        "idpInitiated": null,
+                        "importMode": false,
+                        "ips": [],
+                        "issuer": "",
+                        "jwksUri": "",
+                        "keyId": "",
+                        "mapUserIdToId": false,
+                        "maxGroupsToRetrieve": "",
+                        "messagingServiceSid": "",
+                        "metadataUrl": "",
+                        "metadataXml": "",
+                        "mfa": null,
+                        "name": "",
+                        "nonPersistentAttrs": [
+                            "ethnicity",
+                            "gender"
+                        ],
+                        "passwordComplexityOptions": null,
+                        "passwordDictionary": null,
+                        "passwordHistories": [],
+                        "passwordNoPersonalInfo": null,
+                        "passwordPolicy": "",
+                        "pingFederateBaseUrl": "",
+                        "pkceEnabled": false,
+                        "protocolBinding": "",
+                        "provider": "",
+                        "requestTemplate": "",
+                        "requiresUsername": false,
+                        "scopes": [
+                            "youtube",
+                            "gmail",
+                            "profile",
+                            "email"
+                        ],
+                        "scripts": {},
+                        "setUserRootAttributes": "on_each_login",
+                        "shouldTrustEmailVerifiedConnection": "",
+                        "signInEndpoint": "",
+                        "signOutEndpoint": "",
+                        "signSamlRequest": false,
+                        "signatureAlgorithm": "",
+                        "signingCert": "",
+                        "signingKey": null,
+                        "strategyVersion": 0,
+                        "subject": "",
+                        "syntax": "",
+                        "teamId": "",
+                        "template": "",
+                        "tenantDomain": "",
+                        "tokenEndpoint": "",
+                        "totp": null,
+                        "twilioSid": "",
+                        "twilioToken": "",
+                        "type": "",
+                        "upstreamParams": "",
+                        "useCertAuth": false,
+                        "useKerberos": false,
+                        "useWsfed": false,
+                        "userIdAttribute": "",
+                        "userinfoEndpoint": "",
+                        "validation": null,
+                        "waadCommonEndpoint": false,
+                        "waadProtocol": ""
+                    },
+                    "realms": [
+                        "googleOauth2-b68d006"
+                    ],
+                    "strategy": "google-oauth2"
+                }
+            },
+            "metadata": {
+                "kind": "resource",
+                "mode": "client",
+                "name": "auth0"
+            }
+        }
+    ]
+`
+
+const prcGrpc = `[
         {
             "method": "/pulumirpc.ResourceProvider/Diff",
             "request": {
@@ -486,5 +945,14 @@ func TestConnectionMigration(t *testing.T) {
                 "name": "auth0"
             }
         }
-    ]`)
+    ]
+`
+
+func TestConnectionMigration(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			testutils.ReplaySequence(t, server(), prcGrpc)
+		}
+	}()
+	testutils.ReplaySequence(t, server(), nonPrcGrpc)
 }

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -365,7 +365,7 @@ func TestConnectionMigration(t *testing.T) {
             },
             "response": {
                 "properties": {
-                    "__meta": "{\"schema_version\":\"2\"}",
+                    "metadata": null,
                     "displayName": "",
                     "id": "con_28GC8g8h3O4RUSSM",
                     "isDomainConnection": false,
@@ -402,7 +402,7 @@ func TestConnectionMigration(t *testing.T) {
                         "enabledDatabaseCustomization": false,
                         "entityId": "",
                         "fedMetadataXml": "",
-                        "fieldsMap": "",
+                        "fieldsMap": null,
                         "forwardRequestInfo": false,
                         "from": "",
                         "gatewayAuthentication": null,
@@ -438,10 +438,10 @@ func TestConnectionMigration(t *testing.T) {
                         "requestTemplate": "",
                         "requiresUsername": false,
                         "scopes": [
-                            "youtube",
+                            "email",
                             "gmail",
                             "profile",
-                            "email"
+                            "youtube"
                         ],
                         "scripts": {},
                         "setUserRootAttributes": "on_each_login",
@@ -473,6 +473,7 @@ func TestConnectionMigration(t *testing.T) {
                         "waadCommonEndpoint": false,
                         "waadProtocol": ""
                     },
+                    "showAsButton": null,
                     "realms": [
                         "googleOauth2-b68d006"
                     ],

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -948,7 +948,7 @@ const prcGrpc = `[
     ]
 `
 
-// TODO: Remove non-prc test after enabling PRC by default.
+// TODO[pulumi/pulumi-auth0#587]: Remove non-prc test after enabling PRC by default.
 func TestConnectionMigration(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -948,6 +948,7 @@ const prcGrpc = `[
     ]
 `
 
+// TODO: Remove non-prc test after enabling PRC by default.
 func TestConnectionMigration(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
related to https://github.com/pulumi/pulumi-terraform-bridge/issues/1785

GRPC test asserts on secondary behaviour which changes under PRC - this makes the tests handle both.

Having it handle both makes sure we don't have to synchronise changes here to changes in the bridge, allowing an easier time with downstream tests.