### PR TITLE
Enable zero default schema version for auth0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ sdk/java/gradlew.bat
 
 
 sdk/python/venv
+
+go.work
+go.work.sum

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -121,6 +121,7 @@ func Provider() tfbridge.ProviderInfo {
 				"Pulumi": "3.*",
 			},
 		}, MetadataInfo: tfbridge.NewProviderMetadata(metadata),
+		EnableZeroDefaultSchemaVersion: true,
 	}
 
 	prov.MustComputeTokens(tks.SingleModule("auth0_", mainMod,


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2133

Enables zero default schema version for auth0.