### PR TITLE
Enable accurate bridge previews by default

### DIFF
--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -27,7 +27,6 @@ func server() pulumirpc.ResourceProviderServer {
 	)
 }
 
-// TODO[pulumi/pulumi-auth0#587]: Remove non-prc test after enabling PRC by default.
 func TestConnectionMigration(t *testing.T) {
 	testutils.ReplaySequence(t, server(), `[
         {
@@ -196,6 +195,28 @@ func TestConnectionMigration(t *testing.T) {
                 "detailedDiff": {
                     "options.fieldsMap": {
                         "kind": "DELETE"
+                    },
+                    "options.authParams": {
+                    },
+                    "options.disableSelfServiceChangePassword": {
+                    },
+                    "options.disableSignOut": {
+                    },
+                    "options.enableScriptContext": {
+                    },
+                    "options.fedMetadataXml": {
+                    },
+                    "options.mapUserIdToId": {
+                    },
+                    "options.metadataUrl": {
+                    },
+                    "options.metadataXml": {
+                    },
+                    "options.pingFederateBaseUrl": {
+                    },
+                    "options.pkceEnabled": {
+                    },
+                    "options.upstreamParams": {
                     }
                 },
                 "hasDetailedDiff": true

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -116,6 +116,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 		}, MetadataInfo: tfbridge.NewProviderMetadata(metadata),
 		EnableZeroDefaultSchemaVersion: true,
+		EnableAccurateBridgePreview:    true,
 	}
 
 	prov.MustComputeTokens(tks.SingleModule("auth0_", mainMod,


### PR DESCRIPTION
This enables the Accurate Previews bridge feature for the provider.

part of pulumi/pulumi-terraform-bridge#2598