### PR TITLE
Patch organization_connection

### DIFF
--- a/patches/0004-patch-default-on-organization_connection.patch
+++ b/patches/0004-patch-default-on-organization_connection.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Venelin <venelin@pulumi.com>
+Date: Tue, 15 Apr 2025 10:10:45 +0300
+Subject: [PATCH] patch default on organization_connection
+
+
+diff --git a/internal/auth0/organization/resource_connection.go b/internal/auth0/organization/resource_connection.go
+index 85619bb9..297a7bc9 100644
+--- a/internal/auth0/organization/resource_connection.go
++++ b/internal/auth0/organization/resource_connection.go
+@@ -44,7 +44,6 @@ func NewConnectionResource() *schema.Resource {
+ 			"is_signup_enabled": {
+ 				Type:     schema.TypeBool,
+ 				Optional: true,
+-				Default:  false,
+ 				Description: "Determines whether organization sign-up should be enabled for this " +
+ 					"organization connection. Only applicable for database connections. " +
+ 					"Note: `is_signup_enabled` can only be `true` if `assign_membership_on_login` is `true`.",

--- a/provider/provider_program_test.go
+++ b/provider/provider_program_test.go
@@ -78,6 +78,7 @@ func TestProgramsUpgrade(t *testing.T) {
 	}
 }
 
+// Regression test for https://github.com/pulumi/pulumi-auth0/issues/657
 func TestOrganizationConnection(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/provider/provider_program_test.go
+++ b/provider/provider_program_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/pulumi/providertest/pulumitest/opttest"
 )
 
-const providerName = "auth0"
-const defaultBaselineVersion = "3.3.1"
+const (
+	providerName           = "auth0"
+	defaultBaselineVersion = "3.3.1"
+)
 
 var programs = []string{
 	"test-programs/index_role",
@@ -74,4 +76,15 @@ func TestProgramsUpgrade(t *testing.T) {
 			testProviderUpgrade(t, p)
 		})
 	}
+}
+
+func TestOrganizationConnection(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	pt := pulumitest.NewPulumiTest(t, "test-programs/organization_connection",
+		opttest.LocalProviderPath(providerName, filepath.Join(cwd, "..", "bin")),
+		opttest.SkipInstall(),
+	)
+	pt.Up(t)
 }

--- a/provider/test-programs/organization_connection/Pulumi.yaml
+++ b/provider/test-programs/organization_connection/Pulumi.yaml
@@ -1,0 +1,53 @@
+name: auth0-azure-ad
+runtime: yaml
+description: Auth0 Azure AD Connection and Organization Setup
+
+resources:
+  azureAdConnection:
+    type: auth0:Connection
+    properties:
+      strategy: waad
+      showAsButton: true
+      options:
+        identityApi: azure-active-directory-v1.0
+        clientId: 123456
+        clientSecret: 123456
+        appId: app-id-123
+        tenantDomain: example.onmicrosoft.com
+        domain: example.onmicrosoft.com
+        domainAliases:
+          - example.com
+          - api.example.com
+        iconUrl: https://example.onmicrosoft.com/assets/logo.png
+        useWsfed: false
+        waadProtocol: openid-connect
+        waadCommonEndpoint: false
+        maxGroupsToRetrieve: 250
+        apiEnableUsers: true
+        scopes:
+          - basic_profile
+          - ext_groups
+          - ext_profile
+        setUserRootAttributes: on_each_login
+        shouldTrustEmailVerifiedConnection: never_set_emails_as_verified
+        upstreamParams: |
+          {
+            "screen_name": {
+              "alias": "login_hint"
+            }
+          }
+        nonPersistentAttrs:
+          - ethnicity
+          - gender
+
+  organization:
+    type: auth0:Organization
+    properties:
+      displayName: Test Org
+
+  orgConnection:
+    type: auth0:OrganizationConnection
+    properties:
+      organizationId: ${organization.id}
+      connectionId: ${azureAdConnection.id}
+      assignMembershipOnLogin: true


### PR DESCRIPTION
The resource is not able to be created due to some inconsistent behaviour in the TF Provider. It specifies a default for the `_ is_signup_enabled` property but overrides it during apply. On ours side the property keeps the default value which prevents users from creating the resource.

This PR applies a small patch which just removes the default value for the resource.

Repro due to @guineveresaenger 

fixes https://github.com/pulumi/pulumi-auth0/issues/657