### PR TITLE
[PATCH] Enable pagination on Client Connection

### DIFF
--- a/patches/0005-Enable-pagination-via-Next-on-reading-upstream-conne.patch
+++ b/patches/0005-Enable-pagination-via-Next-on-reading-upstream-conne.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: guineveresaenger <guinevere@pulumi.com>
+Date: Mon, 28 Jul 2025 16:27:42 -0700
+Subject: [PATCH] Enable pagination via Next on reading upstream connection
+ client
+
+
+diff --git a/internal/auth0/connection/resource_client.go b/internal/auth0/connection/resource_client.go
+index 010f0fe8..99953184 100644
+--- a/internal/auth0/connection/resource_client.go
++++ b/internal/auth0/connection/resource_client.go
+@@ -81,13 +81,34 @@ func readConnectionClient(ctx context.Context, data *schema.ResourceData, meta i
+ 	connectionID := data.Get("connection_id").(string)
+ 	clientID := data.Get("client_id").(string)
+ 
+-	enabledClientsResp, err := api.Connection.ReadEnabledClients(ctx, connectionID)
+-	if err != nil {
+-		return diag.FromErr(internalError.HandleAPIError(data, err))
++	// Implement pagination using the Next token
++	var allClients []management.ConnectionEnabledClient
++	var next string
++
++	for {
++		var enabledClientsResp *management.ConnectionEnabledClientList
++		var err error
++
++		if next == "" {
++			enabledClientsResp, err = api.Connection.ReadEnabledClients(ctx, connectionID)
++		} else {
++			enabledClientsResp, err = api.Connection.ReadEnabledClients(ctx, connectionID, management.From(next))
++		}
++
++		if err != nil {
++			return diag.FromErr(internalError.HandleAPIError(data, err))
++		}
++
++		allClients = append(allClients, enabledClientsResp.GetClients()...)
++
++		if !enabledClientsResp.HasNext() {
++			break
++		}
++		next = enabledClientsResp.Next
+ 	}
+ 
+ 	found := false
+-	for _, c := range enabledClientsResp.GetClients() {
++	for _, c := range allClients {
+ 		if c.GetClientID() == clientID {
+ 			found = true
+ 			break


### PR DESCRIPTION
This pull request introduces a new upstream patch.

In a [recent upstream release](https://github.com/auth0/terraform-provider-auth0/releases/tag/v1.22.0), an extra GET call was implemented on Create for ConnectionClients.
This call does not implement pagination properly, so that when there are more clients in existence than clients returned per page, it is possible that Create can fail if the new client's ID is on page 2 of the request.
This intermittent failure was reported in #909.

There is no obvious way to test this. The default clients-returned-per-page is 50; our Auth0 instance does not permit that many clients. 
I've tested this locally by implementing the upstream provider with a very small PerPage for the Client, which reproduced the error reported in #909 reliably. 

This is also something that we should be able to fix upstream, so I'll open a pull request there as well.
