### PR TITLE
Exclude java from provider_program_test.go build tag

### DIFF
--- a/provider/provider_program_test.go
+++ b/provider/provider_program_test.go
@@ -1,5 +1,5 @@
-//go:build !go && !nodejs && !python && !dotnet
-// +build !go,!nodejs,!python,!dotnet
+//go:build !go && !nodejs && !python && !dotnet && !java
+// +build !go,!nodejs,!python,!dotnet,!java
 
 package auth0
 


### PR DESCRIPTION
# DO NOT REVIEW: THIS IS WRONG. ALL SDKS ARE RUNNING THESE TESTS WHICH IS WRONG!

## Summary

- The `provider_program_test.go` build tag was `!go && !nodejs && !python && !dotnet`, which caused `TestOrganizationConnection` to run twice: once in the prerequisites job (no language tag set) and again in the Java job (`java` was not excluded)
- Both runs use the hardcoded connection name `azure-ad-connection`, so the second run races with the first run's deletion, producing a `409 Conflict: A connection with the same name is being deleted`
- Fix: add `java` to the exclusion list so these tests only run once (in prerequisites)

## Test plan

- [ ] Verify Java CI job no longer runs `TestOrganizationConnection`
- [ ] Confirm prerequisites job still runs it as expected

Part of pulumi/pulumi-auth0#1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
