### PR TITLE
Opt in to building the provider binary in the fanout test_provider job

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -7,6 +7,9 @@ env:
     AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
     AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
 makeTemplate: bridged
+# provider_program_test.go tests load the built provider plugin from ./bin, so
+# the fanout test_provider job must build the provider first. See pulumi/ci-mgmt#2336.
+testProviderNeedsProviderBinary: true
 team: ecosystem
 pulumiConvert: 1
 registryDocs: true


### PR DESCRIPTION
provider_program_test.go's tests load the built provider plugin from `./bin`, but the fanout `test_provider` job restores only the tfgen binary. Setting `testProviderNeedsProviderBinary` makes the regenerated workflow build the provider with `make provider_no_deps` before the unit tests run.

This is a source-only opt-in: it takes effect on the next workflow regeneration against the ci-mgmt template change.

Part of #1249
Part of pulumi/ci-mgmt#2336